### PR TITLE
Fix textinput animation when keyboard changes its size

### DIFF
--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -1483,12 +1483,16 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
             scrollView.contentOffset = CGPointMake(contentOffset.x, newOffset);
         }
         
-        // Only for this animation, we set bo to bounce since we want to give the impression that the text input is glued to the keyboard.
-        [self.view slk_animateLayoutIfNeededWithDuration:duration
-                                                  bounce:NO
-                                                 options:(curve<<16)|UIViewAnimationOptionLayoutSubviews|UIViewAnimationOptionBeginFromCurrentState
-                                              animations:animations
-                                              completion:NULL];
+        if (duration == 0) {
+            [self.view layoutIfNeeded];
+        } else {
+            // Only for this animation, we set bo to bounce since we want to give the impression that the text input is glued to the keyboard.
+            [self.view slk_animateLayoutIfNeededWithDuration:duration
+                                                      bounce:NO
+                                                     options:(curve<<16)|UIViewAnimationOptionLayoutSubviews|UIViewAnimationOptionBeginFromCurrentState
+                                                  animations:animations
+                                                  completion:NULL];
+        }
     }
     else {
         animations();


### PR DESCRIPTION
When switching from "normal keyboard" to "emoji keyboard" the keyboard height changes without an animation. Duration in this case is set to 0. Because we're still using an animation here, the textinput position "lags", which results in visual glitches (especially when the new keyboard height is smaller we'll see a black background).