### PR TITLE
Correctly determine inputbarHeight if text changed

### DIFF
--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -711,6 +711,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
         return;
     }
     
+    [_textInputbar layoutIfNeeded];
     CGFloat inputbarHeight = _textInputbar.appropriateHeight;
     
     _textInputbar.rightButton.enabled = [self canPressRightButton];


### PR DESCRIPTION
* Write text in textView
* Add multiple new lines
* Note that at the point were the height of the inputbar does not change anymore, the tableView still gets scrolled

This happens because `_textInputbar.appropriateHeight` returns incorrect values before the layout is done, resulting in this weird scrolling behaviour.