### PR TITLE
Fix button spacing to right button

### DIFF
--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -673,9 +673,10 @@ CGFloat const SLKTextInputbarMinButtonWidth = 44.0;
     NSDictionary *metrics = @{@"top" : @(self.contentInset.top),
                               @"left" : @(self.contentInset.left),
                               @"right" : @(self.contentInset.right),
+                              @"buttonMargin" : @(MIN(self.contentInset.left, self.contentInset.right)),
                               };
     
-    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(left)-[leftButton(0)]-(<=left)-[textView]-(right)-[rightButton(0)]-(right)-|" options:0 metrics:metrics views:views]];
+    [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(left)-[leftButton(0)]-(<=buttonMargin)-[textView]-(buttonMargin)-[rightButton(0)]-(right)-|" options:0 metrics:metrics views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[leftButton(0)]-(0@750)-|" options:0 metrics:metrics views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|-(>=0)-[rightButton]-(<=0)-|" options:0 metrics:metrics views:views]];
     [self addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|-(left@250)-[charCountLabel(<=50@1000)]-(right@750)-|" options:0 metrics:metrics views:views]];


### PR DESCRIPTION
This controller tries to have a equal spacing between buttons <-> input && buttons <-> safe area this happens on a iPhone XR in Landscape mode:
![image](https://user-images.githubusercontent.com/1580193/218534040-0215fc2a-3f86-4008-a5bd-c64caeee91c2.png)

After this PR
![image](https://user-images.githubusercontent.com/1580193/218534101-a476af4a-300b-478f-8e14-110d4eedecf6.png)
