### PR TITLE
Fix keyboard animation for autocompletion on iOS 16

### DIFF
--- a/Source/SLKTextView.m
+++ b/Source/SLKTextView.m
@@ -445,7 +445,13 @@ SLKPastableMediaType SLKPastableMediaTypeFromNSString(NSString *string)
     self.autocorrectionType = enabled ? UITextAutocorrectionTypeDefault : UITextAutocorrectionTypeNo;
     self.spellCheckingType = enabled ? UITextSpellCheckingTypeDefault : UITextSpellCheckingTypeNo;
     
-    [self refreshFirstResponder];
+    if (@available(iOS 16.0, *)) {
+        // On iOS 16 using "refreshFirstResponder" leads to a unwanted keyboard animation
+        // "refreshInputViews" is enough here.
+        [self refreshInputViews];
+    } else {
+        [self refreshFirstResponder];
+    }
 }
 
 - (void)setContentOffset:(CGPoint)contentOffset


### PR DESCRIPTION
Since iOS 16 when adding a "@" to the chat input the keyboard is animated and "jumps" when the completion view will be shown. Instead of resigning and becoming a first responder quickly after each other, looks like `refreshInputViews` is sufficient on iOS 16, even with keyboard suggestions enabled.