### PR TITLE
Improve hiding/showing the input bar and respecting the safe area

### DIFF
--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -497,6 +497,7 @@ CGFloat const SLKTextInputbarMinButtonHeight = 44.0;
     if (!self.isEditing) {
         self.contentViewHC.active = hidden;
         
+        [self slk_updateConstraintConstants];
         [super setNeedsLayout];
         [super layoutIfNeeded];
     }
@@ -726,6 +727,14 @@ CGFloat const SLKTextInputbarMinButtonHeight = 44.0;
     }
     else {
         self.editorContentViewHC.constant = zero;
+
+        // When the inputbar is hidden, we need to hide the buttons as as well
+        if (self->_hidden) {
+            self.leftButtonHC.constant = zero;
+            self.rightButtonHC.constant = zero;
+
+            return;
+        }
         
         CGSize leftButtonSize = [self.leftButton imageForState:self.leftButton.state].size;
         CGSize rightButtonSize = [self.rightButton imageForState:self.rightButton.state].size;

--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -468,9 +468,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     
     // A bottom margin is required for iPhone X
     if (@available(iOS 11.0, *)) {
-        if (!self.textInputbar.isHidden) {
-            return self.view.safeAreaInsets.bottom;
-        }
+        return self.view.safeAreaInsets.bottom;
     }
     
     return 0.0;


### PR DESCRIPTION
Next try with correct base...

When the input bar is hidden, the tableView/scrollView did not respect the bottom safe area, leading to text behind the safe area. Just returning the safe area in all cases is not enough, we also need to make sure the buttons are hidden.