### PR TITLE
Take leading of a font into account for height calculation

### DIFF
--- a/Source/SLKTextInputbar.m
+++ b/Source/SLKTextInputbar.m
@@ -399,8 +399,12 @@ CGFloat const SLKTextInputbarTypingIndicatorHeight  = 24.0;
 - (CGFloat)slk_inputBarHeightForLines:(NSUInteger)numberOfLines
 {
     CGFloat height = self.textView.intrinsicContentSize.height;
+
+    // Since the intrinsicContentSize (see SLKTextView) contains the lineHeight, we remove it here again
     height -= self.textView.font.lineHeight;
-    height += roundf(self.textView.font.lineHeight*numberOfLines);
+
+    height += roundf(self.textView.font.lineHeight * numberOfLines);
+    height += roundf(self.textView.font.leading * numberOfLines);
     height += self.contentInset.top;
     height += self.slk_bottomMargin;
     height += [self slk_typingIndicatorHeight];


### PR DESCRIPTION
The dynamic font we apply to the textView has a `leading` property of `> 0` in contrast to the default system font, where `leading` was always `0`. This is problematic when calculating the height of the `SLKTextInputbar` because we are missing a few pixels and therefore the `SLKTextView` is scrollable, when it should not be scrollable.

How to test:
* Start current talk-ios on master without the modifications of this PR
* Enter a conversation and write a 2 line message in the inputfield
* Hide the keyboard
* Notice that the inputbar is now scrollable, although it should not be scrollable for only 2 lines

- [x] Update talk-ios reference after this is merged